### PR TITLE
Fix for python 3.4

### DIFF
--- a/cemu/parser.py
+++ b/cemu/parser.py
@@ -113,7 +113,9 @@ class CodeParser:
         syscall_names = syscalls.keys()
         for line in code:
             for sysname in syscall_names:
-                pattern = b"__NR_SYS_%s" % sysname
+                # this does not work in Python 3.4, concatenate bytes instead
+                # pattern = b"__NR_SYS_%s" % sysname
+                pattern = b"__NR_SYS_" + sysname
                 if pattern in line:
                     line = line.replace(pattern, b'%d'%syscalls[sysname])
             parsed.append(line)


### PR DESCRIPTION
I'm getting the following error when running cemu under Python 3.4.2 on Debian:

`TypeError: unsupported operand type(s) for %: 'bytes' and 'bytes'`

Apperently, formatting on bytes objects is not supported in Python 3.4? This simple fix uses concatenation of the two bytes objects instead.