### PR TITLE
Aarch64: Change the register size to 64bits

### DIFF
--- a/cemu/arch/arm.py
+++ b/cemu/arch/arm.py
@@ -54,4 +54,4 @@ class AARCH64(Architecture):
         pc
     ]
     syscall_filename = "aarch64"
-    ptrsize = 4
+    ptrsize = 8


### PR DESCRIPTION
Aarch64 execution state provides 64bit registers accessible by names
x0 - x30. Changed the ptrsize to correctly display register values in UI.

https://developer.arm.com/docs/ddi0487/latest/arm-architecture-reference-manual-armv8-for-armv8-a-architecture-profile