### PR TITLE
Fix minor GUI bugs on Windows

### DIFF
--- a/cemu/arch/__init__.py
+++ b/cemu/arch/__init__.py
@@ -17,7 +17,7 @@ class Endianness(enum.Enum):
     BIG_ENDIAN = 2
 
     def __str__(self) -> str:
-        return self.name
+        return self.name.replace("_", " ").title()
 
     def __repr__(self) -> str:
         return self.name

--- a/cemu/arch/__init__.py
+++ b/cemu/arch/__init__.py
@@ -68,21 +68,24 @@ class Architecture:
     @property
     def syscalls(self):
         if not self.__context:
-            mod = __import__("cemu.core")
-            self.__context = getattr(mod, "context")
+            import cemu.core
+
+            self.__context = cemu.core.context
             assert isinstance(self.__context, cemu.core.GlobalContext)
 
         if not self.__syscalls:
-            syscall_dir = SYSCALLS_PATH / cemu.core.context.os
+            syscall_dir = SYSCALLS_PATH / str(self.__context.os)
             fpath = syscall_dir / (self.syscall_filename + ".csv")
             self.__syscalls = {}
-
-            with fpath.open("r") as fd:
-                for row in fd.readlines():
-                    row = [x.strip() for x in row.strip().split(",")]
-                    syscall_number = int(row[0])
-                    syscall_name = row[1].lower()
-                    self.__syscalls[syscall_name] = self.syscall_base + syscall_number
+            if fpath.exists():
+                with fpath.open("r") as fd:
+                    for row in fd.readlines():
+                        row = [x.strip() for x in row.strip().split(",")]
+                        syscall_number = int(row[0])
+                        syscall_name = row[1].lower()
+                        self.__syscalls[syscall_name] = (
+                            self.syscall_base + syscall_number
+                        )
 
         return self.__syscalls
 

--- a/cemu/emulator.py
+++ b/cemu/emulator.py
@@ -1,12 +1,13 @@
+import collections
 from enum import IntEnum, unique
 from multiprocessing import Lock
 from typing import Any, Callable, Optional
 
-import collections
 import unicorn
 
 import cemu.const
 import cemu.core
+import cemu.os
 import cemu.utils
 from cemu.log import dbg, error, info, warn
 
@@ -175,8 +176,14 @@ class Emulator:
             error("VM is not initalized")
             return False
 
+        if len(self.sections) < 0:
+            error("No section declared")
+            return False
+
         for section in self.sections:
-            self.vm.mem_map(section.address, section.size, perms=section.permission.unicorn())
+            self.vm.mem_map(
+                section.address, section.size, perms=section.permission.unicorn()
+            )
             msg = f"Mapping {str(section)}"
 
             if section.content:
@@ -185,6 +192,10 @@ class Emulator:
 
             dbg(f"[vm::setup] {msg}")
 
+        #
+        # Set temporary values to start_addr and end_addr.
+        # Those values will likely be changed when populating text section
+        #
         self.start_addr = self.sections[0].address
         self.end_addr = -1
         return True

--- a/cemu/ui/main.py
+++ b/cemu/ui/main.py
@@ -325,9 +325,10 @@ class CEmuWindow(QMainWindow):
         # Add Architecture menu bar
         archMenu = menubar.addMenu("&Architecture")
         for abi in sorted(Architectures.keys()):
-            archSubMenu = archMenu.addMenu(abi)
+            archSubMenu = archMenu.addMenu(abi.upper())
             for arch in Architectures[abi]:
-                self.archActions[arch.name] = QAction(QIcon(), str(arch), self)
+                label = f"{arch.name:s} / Endian: {str(arch.endianness)} / Syntax: {str(arch.syntax)}"
+                self.archActions[arch.name] = QAction(QIcon(), label, self)
                 if arch == cemu.core.context.architecture:
                     self.archActions[arch.name].setEnabled(False)
                     self.currentAction = self.archActions[arch.name]


### PR DESCRIPTION
 - Make sure `context` exists when parsing for syscalls
 - Changed labelling of `Architecture` to make them it more explicit
 - Always make sure there's at least 1 section when entering the emulator `setup` phase
