### PR TITLE
Fix `hexdump` Qt view crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This should produce a GUI similar to this:
 ### In the terminal
 
 ```bash
-python -m cemu cli
+python -m cemu --cli
 ```
 
 From where you'll end up in a REPL, allowing you to build and run the emulation environment.
@@ -99,11 +99,28 @@ $ python
 
 Then use the provided API to build and run your environment.
 
-## Contribution ##
+## Contribution
 
 `cemu` was created and maintained by myself, [`@_hugsy_`](https://twitter.com/_hugsy_), but kept fresh thanks to [all the contributors](https://github.com/hugsy/cemu/graphs/contributors).
 
 [ ![contributors-img](https://contrib.rocks/image?repo=hugsy/cemu) ](https://github.com/hugsy/cemu/graphs/contributors)
 
-If you just like the tool, consider dropping on Discord (or Twitter or other) a simple *"thanks"*, it is always very appreciated.
+To make contributions, the easiest way to get started is by using [`rye`](https://rye-up.sh) to get everything setup:
+
+```bash
+curl -sSf https://rye.astral.sh/get | bash  # opt
+rye sync
+```
+
+Before submitting a Pull Request, ensure that both linting and formatting of your new code comply with the project's standards. This can be achieved easily as such:
+
+```bash
+rye lint
+rye fmt
+```
+
+Note that any non-compliance will make CI validation fail, therefore preventing your code being merged.
+
+
+But if you just like the tool as a user, consider dropping on Discord (or Twitter or other) a simple *"thanks"*, it is always very appreciated.
 And if you can, consider [sponsoring me](https://github.com/hugsy/sponsors) - it really helps dedicating time and resources to the projects!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,8 @@ allow-direct-references = true
 packages = ["src/cemu"]
 
 [project.scripts]
-cemu = "cemu.__main__:main_cli"
-
-[project.gui-scripts]
-cemu = "cemu.__main__:main_gui"
+cemu-cli = "cemu.__main__:main_cli"
+cemu-gui = "cemu.__main__:main_gui"
 
 [project.urls]
 "Homepage" = "https://github.com/hugsy/cemu"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,10 @@ allow-direct-references = true
 packages = ["src/cemu"]
 
 [project.scripts]
-cemu = "cemu.__main__:main"
+cemu = "cemu.__main__:main_cli"
 
 [project.gui-scripts]
-cemu = "cemu.__main__:main"
+cemu = "cemu.__main__:main_gui"
 
 [project.urls]
 "Homepage" = "https://github.com/hugsy/cemu"

--- a/src/cemu/__main__.py
+++ b/src/cemu/__main__.py
@@ -63,6 +63,6 @@ def main_cli(debug: bool = False):
 if __name__ == "__main__":
     import sys
 
-    path = pathlib.Path(__file__).absolute().parent.parent
+    path = THIS_FILE.parent.parent
     sys.path.append(str(path))
     main(sys.argv)

--- a/src/cemu/__main__.py
+++ b/src/cemu/__main__.py
@@ -42,6 +42,18 @@ def main(argv: list[str]):
         cemu.core.CemuGui()
 
 
+def main_gui():
+    main([])
+
+
+def main_cli():
+    main(
+        [
+            "--cli",
+        ]
+    )
+
+
 if __name__ == "__main__":
     import sys
 

--- a/src/cemu/__main__.py
+++ b/src/cemu/__main__.py
@@ -8,6 +8,8 @@ import cemu.const
 import cemu.core
 import cemu.log
 
+THIS_FILE = pathlib.Path(__file__).absolute()
+
 
 def setup_remote_debug(port: int = cemu.const.DEBUG_DEBUGPY_PORT):
     assert cemu.const.DEBUG
@@ -42,16 +44,20 @@ def main(argv: list[str]):
         cemu.core.CemuGui()
 
 
-def main_gui():
-    main([])
+def main_gui(debug: bool = False):
+    args = [
+        str(THIS_FILE),
+    ]
+    if debug:
+        args.append("--debug")
+    main(args)
 
 
-def main_cli():
-    main(
-        [
-            "--cli",
-        ]
-    )
+def main_cli(debug: bool = False):
+    args = [str(THIS_FILE), "--cli"]
+    if debug:
+        args.append("--debug")
+    main(args)
 
 
 if __name__ == "__main__":

--- a/src/cemu/log.py
+++ b/src/cemu/log.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 import cemu.const
 
-loggers = set()
+loggers: set[Callable] = set()
 
 
 def register_sink(cb: Callable):

--- a/src/cemu/plugins/scratchboard.py
+++ b/src/cemu/plugins/scratchboard.py
@@ -10,8 +10,7 @@ from cemu.ui.main import CEmuWindow
 
 class ScratchboardWidget(QDockWidget):
     def __init__(self, parent: CEmuWindow, *args, **kwargs):
-        super(ScratchboardWidget, self).__init__("Scratchboard", parent)
-        self.parent = parent
+        super().__init__("Scratchboard", parent)
         self.title = "Scratchboard"
         QVBoxLayout()
         self.__editor = QTextEdit()

--- a/src/cemu/ui/main.py
+++ b/src/cemu/ui/main.py
@@ -158,13 +158,13 @@ class CEmuWindow(QMainWindow):
             if not module:
                 continue
 
-            m = module.register(self)
-            if not m:
+            plugin_widget: Optional[QDockWidget] = module.register(self)
+            if not plugin_widget:
                 error(f"The registration of '{path}' failed")
                 continue
 
-            self.__dockable_widgets.append(m)
-            self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, m)
+            self.__dockable_widgets.append(plugin_widget)
+            self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, plugin_widget)
             ok(f"Loaded plugin '{path}'")
             nb_added += 1
         return nb_added

--- a/src/cemu/ui/memory.py
+++ b/src/cemu/ui/memory.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import unicorn
 from PyQt6.QtGui import QFont
@@ -79,7 +79,7 @@ class MemoryWidget(QDockWidget):
             self.editor.setText("VM not running")
             return
 
-        addr: int
+        addr: Optional[int] = None
         msg = "Displaying "
 
         value = self.address.text()

--- a/src/cemu/utils.py
+++ b/src/cemu/utils.py
@@ -2,7 +2,7 @@ import os
 
 import random
 import string
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     import cemu.arch
@@ -14,7 +14,7 @@ DISASSEMBLY_DEFAULT_BASE_ADDRESS = 0x40000
 
 
 def hexdump(
-    source: bytes,
+    source: Union[bytes, bytearray],
     alignment: int = 0x10,
     separator: str = ".",
     show_raw: bool = False,
@@ -34,8 +34,8 @@ def hexdump(
     """
     import cemu.arch
 
-    if not isinstance(source, bytes):
-        raise ValueError("source must be of type `bytes`")
+    if not (isinstance(source, bytes) or isinstance(source, bytearray)):
+        raise ValueError("source must be of type `bytes` or `bytearray`")
 
     if len(separator) != 1:
         raise ValueError("separator must be a single character")


### PR DESCRIPTION
## Description

This PR fixes a crash happening with the Qt memory viewer, when invoking the `hexdump` function with a bytearray (instead of expected `bytes` type).
This was fixed by also allowing bytearray as input for `hexdump`.

This PR also add a minor additional description for contributing in the readme

